### PR TITLE
Export/Import Keystore with Password

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,50 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "asn1.js": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.1.tgz",
+      "integrity": "sha512-aO8EaEgbgqq77IEw+1jfx5c9zTbzvkfuRBuZsSsPnTHMkmd5AI4J6OtITLZFa381jReeaQL67J0GBTUu0+ZTVw==",
+      "requires": {
+        "bn.js": "4.11.8",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      }
+    },
+    "async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "requires": {
+        "lodash": "4.17.10"
+      }
+    },
+    "base-x": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
+      "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+    },
+    "bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "blakejs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
+    },
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
@@ -13,6 +57,76 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
+    "browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "requires": {
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "requires": {
+        "base-x": "3.0.4"
+      }
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "requires": {
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "requires": {
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.3",
+        "md5.js": "1.3.4",
+        "ripemd160": "2.0.2",
+        "sha.js": "2.4.11"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "requires": {
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
+        "sha.js": "2.4.11"
+      }
+    },
+    "drbg.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+      "requires": {
+        "browserify-aes": "1.2.0",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7"
+      }
     },
     "elliptic": {
       "version": "6.4.0",
@@ -28,10 +142,28 @@
         "minimalistic-crypto-utils": "1.0.1"
       }
     },
+    "evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "requires": {
+        "md5.js": "1.3.4",
+        "safe-buffer": "5.1.2"
+      }
+    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "hash-base": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "requires": {
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
+      }
     },
     "hash.js": {
       "version": "1.1.3",
@@ -62,6 +194,67 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "is-promise": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
+      "integrity": "sha1-MVc3YcBX4zwukaq56W2gjO++duU="
+    },
+    "js-sha3": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
+      "integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
+    },
+    "keypair": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.1.tgz",
+      "integrity": "sha1-dgNxknCvtlZO04oiCHoG/Jqk6hs="
+    },
+    "libp2p-crypto": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.13.0.tgz",
+      "integrity": "sha512-i3r1TBec/xYmC5bcpPiIs3OyUAU3iy53OdRdxqawKoWTQPjYB+TyQ4w+otT66Y0sMcw70O0wH3GFAfPmQgFn+g==",
+      "requires": {
+        "asn1.js": "5.0.1",
+        "async": "2.6.1",
+        "browserify-aes": "1.2.0",
+        "bs58": "4.0.1",
+        "keypair": "1.0.1",
+        "libp2p-crypto-secp256k1": "0.2.2",
+        "multihashing-async": "0.4.8",
+        "node-forge": "0.7.5",
+        "pem-jwk": "1.5.1",
+        "protons": "1.0.1",
+        "rsa-pem-to-jwk": "1.1.3",
+        "tweetnacl": "1.0.0",
+        "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+      }
+    },
+    "libp2p-crypto-secp256k1": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/libp2p-crypto-secp256k1/-/libp2p-crypto-secp256k1-0.2.2.tgz",
+      "integrity": "sha1-DdUh8Yq8TjahUuJOmzYwewrpzwU=",
+      "requires": {
+        "async": "2.6.1",
+        "multihashing-async": "0.4.8",
+        "nodeify": "1.0.1",
+        "safe-buffer": "5.1.2",
+        "secp256k1": "3.5.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+    },
+    "md5.js": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+      "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+      "requires": {
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
+      }
+    },
     "minimalistic-assert": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
@@ -85,6 +278,43 @@
         "minimist": "0.0.8"
       }
     },
+    "multihashes": {
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.13.tgz",
+      "integrity": "sha512-HwJGEKPCpLlNlgGQA56CYh/Wsqa+c4JAq8+mheIgw7OK5T4QvNJqgp6TH8gZ4q4l1aiWeNat/H/MrFXmTuoFfQ==",
+      "requires": {
+        "bs58": "4.0.1",
+        "varint": "5.0.0"
+      }
+    },
+    "multihashing-async": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
+      "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
+      "requires": {
+        "async": "2.6.1",
+        "blakejs": "1.1.0",
+        "js-sha3": "0.7.0",
+        "multihashes": "0.4.13",
+        "murmurhash3js": "3.0.1",
+        "nodeify": "1.0.1"
+      }
+    },
+    "murmurhash3js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/murmurhash3js/-/murmurhash3js-3.0.1.tgz",
+      "integrity": "sha1-Ppg+W0fCoG9DpxMXTn5DXKBEuZg="
+    },
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+    },
+    "node-forge": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+      "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
+    },
     "node-localstorage": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.0.tgz",
@@ -93,10 +323,163 @@
         "write-file-atomic": "1.3.4"
       }
     },
+    "nodeify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/nodeify/-/nodeify-1.0.1.tgz",
+      "integrity": "sha1-ZKtpp7268DzhB7TwM1yHwLnpGx0=",
+      "requires": {
+        "is-promise": "1.0.1",
+        "promise": "1.3.0"
+      }
+    },
+    "object-assign": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+      "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+    },
+    "optimist": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+      "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+      "requires": {
+        "wordwrap": "0.0.3"
+      }
+    },
+    "pem-jwk": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pem-jwk/-/pem-jwk-1.5.1.tgz",
+      "integrity": "sha1-eoY3/S9nqCflfAxC4cI8P9Us+wE=",
+      "requires": {
+        "asn1.js": "1.0.3"
+      },
+      "dependencies": {
+        "asn1.js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
+          "integrity": "sha1-KBuj7B8kSP52X5Kk7s+IP+E2S1Q=",
+          "requires": {
+            "bn.js": "1.3.0",
+            "inherits": "2.0.3",
+            "minimalistic-assert": "1.0.0"
+          }
+        },
+        "bn.js": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-1.3.0.tgz",
+          "integrity": "sha1-DbTL+W+PI7dC9by50ap6mZSgXoM=",
+          "optional": true
+        }
+      }
+    },
+    "promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-1.3.0.tgz",
+      "integrity": "sha1-5cyaTIJ45GZP/twBx9qEhCsEAXU=",
+      "requires": {
+        "is-promise": "1.0.1"
+      }
+    },
+    "protocol-buffers-schema": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.3.2.tgz",
+      "integrity": "sha512-Xdayp8sB/mU+sUV4G7ws8xtYMGdQnxbeIfLjyO9TZZRJdztBGhlmbI5x1qcY4TG5hBkIKGnc28i7nXxaugu88w=="
+    },
+    "protons": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/protons/-/protons-1.0.1.tgz",
+      "integrity": "sha512-+0ZKnfVs+4c43tbAQ5j0Mck8wPcLnlxUYzKQoB4iDW4ocdXGnN4P+0dDbgX1FTpoY9+7P2Tn2scJyHHqj+S/lQ==",
+      "requires": {
+        "protocol-buffers-schema": "3.3.2",
+        "safe-buffer": "5.1.2",
+        "signed-varint": "2.0.1",
+        "varint": "5.0.0"
+      }
+    },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "requires": {
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
+      }
+    },
+    "rsa-pem-to-jwk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rsa-pem-to-jwk/-/rsa-pem-to-jwk-1.1.3.tgz",
+      "integrity": "sha1-JF52vbfnI0z+58oDLTG1TDj6uY4=",
+      "requires": {
+        "object-assign": "2.1.1",
+        "rsa-unpack": "0.0.6"
+      }
+    },
+    "rsa-unpack": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/rsa-unpack/-/rsa-unpack-0.0.6.tgz",
+      "integrity": "sha1-9Q69VqYoN45jHylxYQJs6atO3bo=",
+      "requires": {
+        "optimist": "0.3.7"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "secp256k1": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
+      "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
+      "requires": {
+        "bindings": "1.3.0",
+        "bip66": "1.1.5",
+        "bn.js": "4.11.8",
+        "create-hash": "1.2.0",
+        "drbg.js": "1.0.1",
+        "elliptic": "6.4.0",
+        "nan": "2.10.0",
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "requires": {
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "signed-varint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
+      "integrity": "sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=",
+      "requires": {
+        "varint": "5.0.0"
+      }
+    },
     "slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
       "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+    },
+    "tweetnacl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
+      "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+    },
+    "varint": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.0.tgz",
+      "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
+    },
+    "webcrypto-shim": {
+      "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "write-file-atomic": {
       "version": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "license": "MIT",
   "dependencies": {
     "elliptic": "^6.4.0",
+    "libp2p-crypto": "^0.13.0",
+    "libp2p-crypto-secp256k1": "^0.2.2",
     "mkdirp": "^0.5.1",
     "node-localstorage": "^1.3.0"
   }

--- a/src/keystore.js
+++ b/src/keystore.js
@@ -70,7 +70,7 @@ class Keystore {
     return Promise.resolve(res)
   }
 
-  async exportKeystore(id, password) {
+  async exportKey(id, password) {
     var data = Buffer.from(this._storage.getItem(id))
     var res = {id:id, data: data}
     //Need something better than JSON
@@ -92,12 +92,12 @@ class Keystore {
     return res
   }
 
-  async importKeystore(exportedKeystore, password) {
-    var data = exportedKeystore.data
-    const id = exportedKeystore.id
+  async importKey(exportedKey, password) {
+    var data = exportedKey.data
+    const id = exportedKey.id
     if (password) {
-      const IV  = exportedKeystore.IV
-      const salt = exportedKeystore.salt
+      const IV  = exportedKey.IV
+      const salt = exportedKey.salt
       const hashedPassword = this.hashPassword(password, salt)
       await crypto.aes.create(hashedPassword, IV, async (err, aes) => {
         if (!err) {

--- a/test/exportAndImport.js
+++ b/test/exportAndImport.js
@@ -1,0 +1,20 @@
+const Keystore = require('../index-nodejs.js')
+const assert = require('assert')
+
+async function test(id, password){ 
+  var keystore = Keystore.create('./.storage')
+  key = keystore.createKey(id)
+  encryptedKeystore = await keystore.exportKeystore(id, password)
+  var keystore2 = Keystore.create('./.storage2')
+  await keystore2.importKeystore(encryptedKeystore, password)
+  key1 = keystore2.getKey(id)
+  assert(await keystore.exportPublicKey(key) === await keystore2.exportPublicKey(key1), "Keys don't match")
+}
+
+async function runTests(){
+  await test(0, 'password')
+  await test(1)
+  console.log("Tests Passed")
+}
+
+runTests()

--- a/test/exportAndImport.js
+++ b/test/exportAndImport.js
@@ -4,9 +4,9 @@ const assert = require('assert')
 async function test(id, password){ 
   var keystore = Keystore.create('./.storage')
   key = keystore.createKey(id)
-  encryptedKeystore = await keystore.exportKeystore(id, password)
+  encryptedKeystore = await keystore.exportKey(id, password)
   var keystore2 = Keystore.create('./.storage2')
-  await keystore2.importKeystore(encryptedKeystore, password)
+  await keystore2.importKey(encryptedKeystore, password)
   key1 = keystore2.getKey(id)
   assert(await keystore.exportPublicKey(key) === await keystore2.exportPublicKey(key1), "Keys don't match")
 }


### PR DESCRIPTION
This uses the libp2p-crypto library to add AES encryption for exporting and importing keys.

Two public functions were added to the class:

```js
exportKey(id, password):
```
returns a promise of an object containing the id and the keys corresponding to id. If a password is provided it is encrypted and a salt and IV are added.

```js
importKey(exportedKeystore, password)
```
imports the keys and their corresponding id

There is also a new test directory with a single test that shows this works with and without passwords.

Later these functions can be used by orbit-db so that accounts can be imported and exported.

The library also includes `secp256k1`, but I didn't want to change the current implementation, perhaps that would be a future PR.