### PR TITLE
Improve performance of the new keystore implementation

### DIFF
--- a/src/keystore.js
+++ b/src/keystore.js
@@ -10,9 +10,9 @@ class Keystore {
 
   hasKey (id) {
     let hasKey = false
+    let storedKey = this._storage.getItem(id)
     try {
-      hasKey = this._storage.getItem(id) !== undefined
-        && this._storage.getItem(id) !== null
+      hasKey = storedKey !== undefined && storedKey !== null
     } catch (e) {
       // Catches 'Error: ENOENT: no such file or directory, open <path>'
       console.error('Error: ENOENT: no such file or directory')

--- a/src/keystore.js
+++ b/src/keystore.js
@@ -34,19 +34,24 @@ class Keystore {
   }
 
   getKey (id) {
-    let key = JSON.parse(this._storage.getItem(id))
+    const storedKey = this._storage.getItem(id)
 
-    if (!key)
+    if (!storedKey)
       return
 
-    const k = ec.keyPair({
-      pub:  key.publicKey,
-      priv: key.privateKey,
+    const deserializedKey = JSON.parse(storedKey)
+
+    if (!deserializedKey)
+      return
+
+    const key = ec.keyPair({
+      pub:  deserializedKey.publicKey,
+      priv: deserializedKey.privateKey,
       pubEnc: 'hex',
       privEnc: 'hex',
     })
 
-    return k
+    return key
   }
 
   sign(key, data) {


### PR DESCRIPTION
This PR will together with https://github.com/orbitdb/orbit-db-identity-provider/pull/1 will improve the performance of Keystore and IdentityProvider by avoiding unnecessary calls to the localStorage to get the key.

This PR will cache the key from storage in hasKey() and returns early if storage didn't have the key for id in getKey(). I also improved the variable naming a little bit in getKey().