### PR TITLE
fix: verifier data to buffer

### DIFF
--- a/src/verifiers/verifierv1.js
+++ b/src/verifiers/verifierv1.js
@@ -1,5 +1,7 @@
 'use strict'
 const crypto = require('libp2p-crypto')
+const Buffer = require('safe-buffer/').Buffer
+
 module.exports = {
   verify: async (signature, publicKey, data) => {
     if (!signature) {
@@ -10,6 +12,10 @@ module.exports = {
     }
     if (!data) {
       throw new Error('Given input data was undefined')
+    }
+
+    if (!Buffer.isBuffer(data)) {
+      data = Buffer.from(data)
     }
 
     const isValid = (key, msg, sig) => new Promise((resolve, reject) => {


### PR DESCRIPTION
This fixes an issue where verifying an identity in an entry fails right now

The signing in the identity provider passes id as data - https://github.com/orbitdb/orbit-db-identity-provider/blob/master/src/identities.js#L52 

But is converted to a buffer here - https://github.com/orbitdb/orbit-db-keystore/blob/master/src/keystore.js#L178

While the verifier in the identity provider is passed id as data - https://github.com/orbitdb/orbit-db-identity-provider/blob/master/src/identities.js#L60

It isn't converted to a buffer, thus the verification fails. 

Decide to add fix here, since coerced to buffer in sign function here, but could also make the fix in the identity provider if that made more sense for any reason. 

Note: doesn't show up in current release since verifyIdentity not used in IPFS AC (looked like IPFS AC is the default still)  - related here 
https://github.com/orbitdb/orbit-db-access-controllers/pull/31/files 