### PR TITLE
chore: remove libp2p-crypto-secp256k1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "level": "~5.0.1",
     "leveldown": "~5.1.1",
     "levelup": "~4.1.0",
-    "libp2p-crypto": "^0.16.0",
-    "libp2p-crypto-secp256k1": "^0.3.0",
+    "libp2p-crypto": "^0.17.8",
     "lru": "^3.1.0",
     "mkdirp": "^0.5.5",
     "safe-buffer": "^5.2.1"


### PR DESCRIPTION
DEPRECATED: libp2p-crypto-secp256k1
https://github.com/libp2p/js-libp2p-crypto-secp256k1