### PR TITLE
No longer returned Promise.resolve/reject from async functions.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,13 @@
 version: 2.1
 
 executors:
-  node12-browsers:
+  node-browsers:
     docker:
-      - image: circleci/node:12-browsers
+      - image: cimg/node:16.17-browsers
 
 jobs:
   setup:
-    executor: node12-browsers
+    executor: node-browsers
     steps:
       - checkout
       - run: mkdir -p /tmp/workspace
@@ -25,19 +25,19 @@ jobs:
             - conf
             - package.json
   test-node:
-    executor: node12-browsers
+    executor: node-browsers
     steps:
       - attach_workspace:
           at: ./
       - run: npm run test:node
   test-browser:
-    executor: node12-browsers
+    executor: node-browsers
     steps:
       - attach_workspace:
           at: ./
       - run: npm run test:browser
   build:
-    executor: node12-browsers
+    executor: node-browsers
     steps:
       - attach_workspace:
           at: ./

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "elliptic": "^6.5.4",
-    "level": "~5.0.1",
+    "level": "~7.0.0",
     "libp2p-crypto": "^0.19.4",
     "lru": "^3.1.0",
     "mkdirp": "^0.5.5",

--- a/src/keystore.js
+++ b/src/keystore.js
@@ -37,16 +37,15 @@ class Keystore {
   }
 
   async open () {
-    if (this._store) {
-      await this._store.open()
-      return Promise.resolve()
+    if (!this._store) {
+      throw new Error('Keystore: No store found to open')
     }
-    return Promise.reject(new Error('Keystore: No store found to open'))
+    await this._store.open()
   }
 
   async close () {
     if (!this._store) return
-    await this._upgraded
+    await this._upgrade()
     await this._store.close()
   }
 
@@ -83,7 +82,7 @@ class Keystore {
       throw new Error('id needed to check a key')
     }
     if (this._store.status && this._store.status !== 'open') {
-      return Promise.resolve(null)
+      return null
     }
     if (!this._upgraded) {
       await this._upgrade()
@@ -106,7 +105,7 @@ class Keystore {
       throw new Error('id needed to create a key')
     }
     if (this._store.status && this._store.status !== 'open') {
-      return Promise.resolve(null)
+      return null
     }
     if (!this._upgraded) {
       await this._upgrade()
@@ -139,7 +138,7 @@ class Keystore {
       await this.open()
     }
     if (this._store.status && this._store.status !== 'open') {
-      return Promise.resolve(null)
+      return null
     }
     if (!this._upgraded) {
       await this._upgrade()


### PR DESCRIPTION
I reviewed the code and found one potential logic error and made several minor fixes.

The minor fixes all related to returning `Promise.resolve`/`reject` from an async function. A practice that was only partially present within the file and is no longer  now.

The logic error relates to the `close` function. This function originally had a line `await this._upgraded` - which did nothing but convert `this._upgraded` to a resolved Promise to be thrown away. I guess this was a typo and replaced it by calling `this._upgrade()` instead. But since it could be intended behavior, I think it worth mentioning here.

Tests succeed locally.